### PR TITLE
오류 아닌데 자꾸 오류라고 떠서 수정

### DIFF
--- a/client/src/components/template/TemplateLayout.vue
+++ b/client/src/components/template/TemplateLayout.vue
@@ -1,10 +1,12 @@
 <template>
-  <Header />
-  <SlideMenu />
-  <div class="content-container">
-    <router-view />
+  <div>
+    <Header />
+    <SlideMenu />
+    <div class="content-container">
+      <router-view />
+    </div>
+    <Navigation />
   </div>
-  <Navigation />
 </template>
 
 <script>


### PR DESCRIPTION
Vue3에서는 template 코드 안에 root 태그가 없어도 되는데
eslint가 멍청해서 자꾸 잡아대서 수정
Error Msg : 'The template root requires exactly one element'